### PR TITLE
Use the email field of the author if the name field is not set

### DIFF
--- a/utility/feedfetcher.php
+++ b/utility/feedfetcher.php
@@ -120,7 +120,11 @@ class FeedFetcher implements IFeedFetcher {
 
 		$author = $simplePieItem->get_author();
 		if ($author !== null) {
-			$item->setAuthor(html_entity_decode($author->get_name()));
+			if ($author->get_name()) {
+				$item->setAuthor(html_entity_decode($author->get_name()));
+			} else {
+				$item->setAuthor(html_entity_decode($author->get_email()));
+			}
 		}
 
 		// TODO: make it work for video files also


### PR DESCRIPTION
The email field seems to be the default field SimplePie uses if it's not specified by the feed.

This fixes a problem where no author is displayed for certain feeds such as http://planetkde.org
