### PR TITLE
modify fetch to pass on getFavicon parameter

### DIFF
--- a/utility/fetcher.php
+++ b/utility/fetcher.php
@@ -40,10 +40,10 @@ class Fetcher {
 	}
 
 
-	public function fetch($url){
+	public function fetch($url, $getFavicon=true){
 		foreach($this->fetchers as $fetcher){
 			if($fetcher->canHandle($url)){
-				return $fetcher->fetch($url);
+				return $fetcher->fetch($url, $getFavicon);
 			}
 		}
 	}


### PR DESCRIPTION
[Issue 218](https://github.com/owncloud/news/issues/218)

second PR for this issue, code worked but was never used, except in the tests :/ Unlike the tests the implemented code used Fetcher::fetch to call FeedFetcher::fetch which did not use the second parameter which untfortunately resulted in $getFavicon=true in FeedFetcher::fetch
