### PR TITLE
Updater: "Runonce" functionality was missing an argument

### DIFF
--- a/bin/updater.py
+++ b/bin/updater.py
@@ -154,7 +154,7 @@ def main():
 
     # create the updater and run the threads
     updater = Updater(args.url, args.threads, args.interval, args.user,
-        args.password, args.timeout)
+        args.password, args.timeout, args.runonce)
     updater.run()
 
 


### PR DESCRIPTION
The updater will now get called correctly with the new runonce argument. I forgot to include the line in my previous commit ( 3fa2c37bd48ef22937c5644995ac443f557c0871 as in #310 ).
