### PR TITLE
ArticleEnhancer: Transform relative to absolute URLs

### DIFF
--- a/utility/articleenhancer/articleenhancer.php
+++ b/utility/articleenhancer/articleenhancer.php
@@ -56,6 +56,7 @@ abstract class ArticleEnhancer {
 
 
 	public function enhance($item){
+
 		foreach($this->regexXPathPair as $regex => $search) {
 
 			if(preg_match($regex, $item->getUrl())) {
@@ -71,6 +72,7 @@ abstract class ArticleEnhancer {
 
 				$dom = new \DOMDocument();
 				@$dom->loadHTML($body);
+
 				$xpath = new \DOMXpath($dom);
 				$xpathResult = $xpath->evaluate($search);
 
@@ -78,6 +80,9 @@ abstract class ArticleEnhancer {
 				if(!is_string($xpathResult)) {
 					$xpathResult = $this->domToString($xpathResult);
 				}
+				
+				// convert all relative to absolute URLs
+				$xpathResult = $this->substituteRelativeLinks($xpathResult, $item->getUrl());
 
 				$sanitizedResult = $this->purifier->purify($xpathResult);
 				$item->setBody($sanitizedResult);
@@ -89,10 +94,103 @@ abstract class ArticleEnhancer {
 
 
 	/**
+	 * Method which converts all relative "href" and "src" URLs of
+	 * a HTML snippet with their absolute equivalent
+	 * @param string $xmlString a HTML snippet as string with the relative URLs to be replaced
+	 * @param string $absoluteUrl the approptiate absolute url of the HTML snippet
+	 * @return string the result HTML snippet as a string
+	 */
+	protected function substituteRelativeLinks($xmlString, $absoluteUrl) {
+		$dom = new \DOMDocument();
+		$dom->preserveWhiteSpace = false;
+
+		// return, if xml is empty or loading the HTML fails
+		if( trim($xmlString) == "" || !$dom->loadHTML($xmlString) ) {
+			return $xmlString;
+		}
+
+		// remove <!DOCTYPE 
+		$dom->removeChild($dom->firstChild);            
+		// remove <html></html> 
+		$dom->replaceChild($dom->firstChild->firstChild, $dom->firstChild);
+		
+		$substitution = array("href", "src");
+
+		foreach ($substitution as $attribute) {
+			$xpath = new \DOMXpath($dom);
+			$xpathResult = $xpath->query("//*[@".$attribute." and not(contains(@".$attribute.", '://')) and not(starts-with(@".$attribute.", 'mailto:'))]");
+			foreach ($xpathResult as $linkNode) {
+				$urlElement = $linkNode->attributes->getNamedItem($attribute);
+				$urlElement->nodeValue = $this->relativeToAbsoluteUrl( $urlElement->nodeValue, $absoluteUrl );
+			}
+		}
+
+		// save dom to string and remove <body></body>
+		$xmlString = substr(trim($dom->saveHTML()), 6, -7);
+		// domdocument spoils the string with line breaks between the elements. strip them.
+		$xmlString = str_replace("\n", "", $xmlString);
+
+		return $xmlString;
+	}
+
+
+	/**
+	 * Method which builds a URL by taking a relative URL and its corresponding
+	 * absolute URL
+	 * For examle relative URL "../example/path/file.php?a=1#anchor" and
+	 * absolute URL "https://username:password@www.website.com/subfolder/index.html"
+	 * will result in "https://username:password@www.website.com/example/path/file.php?a=1#anchor"
+	 * @param string $relativeUrl the relative URL
+	 * @param string $absoluteUrl the absolute URL with at least scheme and host
+	 * @return string the resulting absolute URL
+	 */
+	protected function relativeToAbsoluteUrl($relativeUrl, $absoluteUrl) {
+		$abs = parse_url($absoluteUrl);
+
+		$newUrl =	$abs["scheme"]."://"
+					.( (isset($abs["user"])) ? $abs["user"] . ( (isset($abs["pass"])) ? ":".$abs["pass"] : "") . "@" : "" )
+					.$abs["host"]
+					.( (isset($abs["port"])) ? ":".$abs["port"] : "" );
+
+		if(substr(trim($relativeUrl), 0, 1) == "/") {
+			// we have a relative url like "/a/path/file"
+			return $newUrl . $relativeUrl;
+		} else {
+			// we have a relative url like "a/path/file", handle "."" and ".." directories
+
+			// the starting point is the absolute path, but with out the last part (we don't need the file name)
+			$newPath = explode("/", substr($abs["path"], 1) );
+			array_pop($newPath);
+
+			$relPath = parse_url($relativeUrl, PHP_URL_PATH);
+			$relPath = explode("/", $relPath);
+
+			// cross the relative and the absolute path
+			for($i=0; $i<count($relPath)-1; $i++) {
+				if($relPath[$i] == ".") {
+					continue;
+				} elseif($relPath[$i] == "..") {
+					array_pop($newPath);
+				} else {
+					$newPath[] = $relPath[$i];
+				}
+			}
+
+			// add the last part (the file name) of the relative URL
+			$newPath[] = $relPath[ count($relPath)-1 ];
+			$newPath = implode("/", $newPath);
+
+			$rel = parse_url($relativeUrl);
+			return $newUrl . "/" . $newPath
+					. ( (isset($rel["query"]))		? "?".$rel["query"]		: "")
+					. ( (isset($rel["fragment"]))	? "#".$rel["fragment"]	: "");
+		}
+	}
+
+
+	/**
 	 * Method which turns an xpath result to a string
-	 * Assumes that the result matches a single element. If the result 
-	 * is not a single element, you can customize it by overwriting this
-	 * method
+	 * you can customize it by overwriting this method
 	 * @param $xpathResult the result from the xpath query
 	 * @return the result as a string
 	 */
@@ -106,9 +204,9 @@ abstract class ArticleEnhancer {
 
 
 	protected function toInnerHTML($node) {
-		$dom = new \DOMDocument();     
+		$dom = new \DOMDocument();
 		$dom->appendChild($dom->importNode($node, true));
-		return trim($dom->saveHTML());
+		return trim($dom->saveHTML($dom->documentElement));
 	}
 
 


### PR DESCRIPTION
By enhancing articles with the help of the ArticleEnhancer, relative links and images of the extracted sites become unaccessible. These two functions transform every relative "href" and "src" URLs within the extracted XPath-results into absolute URLs.

Example:
relative URL:

```
../a/relative/url.html?a=1#b
```

appropriate absolute URL:

```
https://www.explosm.net/all/312
```

resulting absolute URL:

```
https://www.explosm.net/a/relative/url.html?a=1#b
```
