### PR TITLE
FIX oc6 style with Firefox

### DIFF
--- a/css/owncloud6.css
+++ b/css/owncloud6.css
@@ -9,7 +9,7 @@
 }
 
 #app-navigation .rename-feed > input {
-	width: 215px;
+	width: 208px;
 	height: 32px;
 	border-right: 1px solid #ddd;
 	border-radius: 2px;


### PR DESCRIPTION
This commit fixes the previous merge (rename feed feature) improving oc6 style with Firefox.

Some improvements can still be made but, at least, feature is usable with this fix.
