### PR TITLE
fallback to using the feed link if an item doesn't specificy a link

### DIFF
--- a/fetcher/feedfetcher.php
+++ b/fetcher/feedfetcher.php
@@ -94,9 +94,10 @@ class FeedFetcher implements IFeedFetcher {
 		try {
 			// somehow $simplePie turns into a feed after init
 			$items = array();
+			$permaLink = $simplePie->get_permalink();
 			if ($feedItems = $simplePie->get_items()) {
 				foreach($feedItems as $feedItem) {
-					array_push($items, $this->buildItem($feedItem, $simplePie->get_permalink()));
+					array_push($items, $this->buildItem($feedItem, $permaLink));
 				}
 			}
 

--- a/tests/unit/fetcher/FeedFetcherTest.php
+++ b/tests/unit/fetcher/FeedFetcherTest.php
@@ -160,14 +160,14 @@ class FeedFetcherTest extends \OCA\AppFramework\Utility\TestUtility {
 	}
 
 
-	private function expectCore($method, $return) {
-		$this->core->expects($this->once())
+	private function expectCore($method, $return, $count = 1) {
+		$this->core->expects($this->exactly($count))
 			->method($method)
 			->will($this->returnValue($return));
 	}
 
-	private function expectItem($method, $return) {
-		$this->item->expects($this->once())
+	private function expectItem($method, $return, $count = 1) {
+		$this->item->expects($this->exactly($count))
 			->method($method)
 			->will($this->returnValue($return));
 	}
@@ -236,7 +236,7 @@ class FeedFetcherTest extends \OCA\AppFramework\Utility\TestUtility {
 
 	private function createFeed($hasFeedFavicon=false, $hasWebFavicon=false) {
 		$this->expectCore('get_title', $this->feedTitle);
-		$this->expectCore('get_permalink', $this->feedLink);
+		$this->expectCore('get_permalink', $this->feedLink, 2);
 
 		$feed = new Feed();
 		$feed->setTitle(html_entity_decode($this->feedTitle));
@@ -280,7 +280,7 @@ class FeedFetcherTest extends \OCA\AppFramework\Utility\TestUtility {
 
 	public function testFetchMapItemsNoFeedTitleUsesUrl(){
 		$this->expectCore('get_title', '');
-		$this->expectCore('get_permalink', $this->feedLink);
+		$this->expectCore('get_permalink', $this->feedLink, 2);
 
 		$feed = new Feed();
 		$feed->setTitle($this->url);
@@ -340,7 +340,7 @@ class FeedFetcherTest extends \OCA\AppFramework\Utility\TestUtility {
 
 	public function testFetchMapItemsGetFavicon() {
 		$this->expectCore('get_title', $this->feedTitle);
-		$this->expectCore('get_permalink', $this->feedLink);
+		$this->expectCore('get_permalink', $this->feedLink, 2);
 
 		$feed = new Feed();
 		$feed->setTitle(html_entity_decode($this->feedTitle));
@@ -366,7 +366,7 @@ class FeedFetcherTest extends \OCA\AppFramework\Utility\TestUtility {
 
 	public function testFetchMapItemsNoGetFavicon() {
 		$this->expectCore('get_title', $this->feedTitle);
-		$this->expectCore('get_permalink', $this->feedLink);
+		$this->expectCore('get_permalink', $this->feedLink, 2);
 
 		$feed = new Feed();
 		$feed->setTitle(html_entity_decode($this->feedTitle));


### PR DESCRIPTION
This prevents items from having an empty url which, besides being a bad ux, breaks postgresql who interprets the empty string as null (oracle to iirc)
