### PR TITLE
fallback to feed url if simplepie doesnt fetch a permanent link

### DIFF
--- a/fetcher/feedfetcher.php
+++ b/fetcher/feedfetcher.php
@@ -196,7 +196,13 @@ class FeedFetcher implements IFeedFetcher {
 
 		$feed->setTitle($title);
 		$feed->setUrl($url);
-		$feed->setLink($simplePieFeed->get_permalink());
+
+		$link = $simplePieFeed->get_permalink();
+		if (!$link) {
+			$link = $url;
+		}
+		$feed->setLink($link);
+
 		$feed->setAdded($this->time->getTime());
 
 		if ($getFavicon) {


### PR DESCRIPTION
see discussion in https://github.com/owncloud/news-mobile/issues/18

if the link field is empty there are also issue with fetching the favicon 

similar to #460 but for feed instead of items
