### PR TITLE
Don't throw Exception when renaming folder

### DIFF
--- a/businesslayer/folderbusinesslayer.php
+++ b/businesslayer/folderbusinesslayer.php
@@ -114,8 +114,6 @@ class FolderBusinessLayer extends BusinessLayer {
 	 * @return Folder the updated folder
 	 */
 	public function rename($folderId, $folderName, $userId){
-		$this->validateFolder($folderName, $userId);
-
 		$folder = $this->find($folderId, $userId);
 		$folder->setName($folderName);
 		return $this->mapper->update($folder);


### PR DESCRIPTION
The call to `validateFolder()` throws an exception when the folder exists. That's not very convenient in a rename method ;)

@Raydiation @cosenal 
