### PR TITLE
fix generated classnames for pgsql itemmapper

### DIFF
--- a/db/postgres/itemmapper.php
+++ b/db/postgres/itemmapper.php
@@ -36,6 +36,7 @@ class ItemMapper extends \OCA\News\Db\ItemMapper {
 
 	public function __construct(API $api){
 		parent::__construct($api);
+		$this->entityClass = '\OCA\News\Db\Item';
 	}
 
 
@@ -78,6 +79,4 @@ class ItemMapper extends \OCA\News\Db\ItemMapper {
 		}
 
 	}
-
-
 }


### PR DESCRIPTION
The extra namespace for the postgresql item mapper causes invalid class names to be determined (e.g. `OCA\News\Db\Postgres\Item`)

cc @Raydiation 
