### PR TITLE
heise developer & open

### DIFF
--- a/articleenhancer/xpathenhancers.json
+++ b/articleenhancer/xpathenhancers.json
@@ -84,6 +84,12 @@
 	"heise.de/newsticker": {
 		"%heise.de%": "//*[@class='meldung_wrapper']/*[not(contains(@class, 'dossier'))]"
 	},
+	"heise.de/developer": {
+		"%heise.de%": "//*[@class='meldung_wrapper']/*[not(contains(@class, 'dossier'))]"
+	},
+	"heise.de/open/news": {
+		"%heise.de%": "//*[@class='meldung_wrapper']/*[not(contains(@class, 'dossier'))]"
+	},
 	"spiegel.de": {
 		"%spiegel.de/(?!.*video).*%": "//p[@class='article-intro'] | //*[@itemprop='description' and not(ancestor::*[contains( normalize-space( @class ), 'article-section' )]) ] | //*[(@class='spPanoImageTeaserPic' or @class='spPanoGalleryTeaserPic' or @class='spPanoPlayerTeaserPic') and not(ancestor::*[contains( normalize-space( @class ), 'article-section' )])] | //*[@class='image-buttons-panel' and not(ancestor::*[contains( normalize-space( @class ), 'article-section' )])]/*[1]/img | //*[@class='article-image-description' and not(ancestor::*[contains( normalize-space( @class ), 'article-section' )]) ]/p | //*[@id='content-main']/*[@id='js-article-column']/div[contains( normalize-space( @class ), 'article-section' )]"
 	},


### PR DESCRIPTION
I already use http://www.heise.de/newsticker/heise-atom.xml

And this is just a copy to get it work with:
http://www.heise.de/open/news/news-atom.xml
http://www.heise.de/developer/rss/news-atom.xml

Maybe this could be included in the first rule.
