### PR TITLE
article enhancer for TU Chemnitz

### DIFF
--- a/articleenhancer/xpathenhancers.json
+++ b/articleenhancer/xpathenhancers.json
@@ -110,5 +110,8 @@
 	},
 	"omgubuntu.co.uk": {
 		"%www.omgubuntu.co.uk%": "//div[@class=\"entry-content\"]"
+	},
+	"tu-chemnitz.de/tu/presse/": {
+		"%tu-chemnitz.de%": "//div[contains(@class,'page-content')]/*[preceding-sibling::h1 and following-sibling::div[@id]]"
 	}
 }


### PR DESCRIPTION
I woul like to add something like:

```
"tu-chemnitz.de/tu/presse/": {
    "%tu-chemnitz.de%": {
        "%<h4>%": "<strong>",
        "%</h4>%": "</strong>"
    }
}
```

to the regexenhancer but it then enhances nothing and the item from the feed is shown.
