### PR TITLE
Sort by publication date instead of post id

### DIFF
--- a/db/itemmapper.php
+++ b/db/itemmapper.php
@@ -33,7 +33,7 @@ class ItemMapper extends Mapper implements IMapper {
 				'ON `folders`.`id` = `feeds`.`folder_id` ' .
 			'WHERE `feeds`.`folder_id` = 0 ' .
 				'OR `folders`.`deleted_at` = 0 ' .
-			'ORDER BY `items`.`id` DESC';
+			'ORDER BY `items`.`pub_date` DESC, `items`.`id` DESC';
 	}
 
 	private function makeSelectQueryStatus($prependTo, $status) {

--- a/templates/part.items.php
+++ b/templates/part.items.php
@@ -3,7 +3,7 @@
 <ul>
 	<li class="feed_item"
 
-		ng-repeat="item in itemBusinessLayer.getAll() | orderBy:['-id'] "
+		ng-repeat="item in itemBusinessLayer.getAll() | orderBy:['-pubDate'] "
 		ng-class="{ read: item.isRead(), compact: isCompactView(), open: item.active}"
 		data-id="{{ item.id }}"
 		ng-click="itemBusinessLayer.setRead(item.id)">


### PR DESCRIPTION
Hello.

This is a proposition, not a "bug".
I use it on my personal installation.

What it does ?
I think is not revelant to display posts by insert order (like on database).
If you have a RSS feed that don't sort its entries by the publication date, the order will be missed up compared with the posts displayed on the real website.

So, is up to you.
Have a nice day.
Xéfir Destiny
