### PR TITLE
Fix button positions in the new layout

### DIFF
--- a/css/feeds.css
+++ b/css/feeds.css
@@ -222,7 +222,7 @@ button.action:hover {
 
 .rename-feed .action-button {
 	background-position: center;
-	background-repeat: no-repeat;	
+	background-repeat: no-repeat;
 }
 
 .rename-feed .back-button {
@@ -231,7 +231,7 @@ button.action:hover {
 }
 
 .rename-feed .create-button {
-	border-radius: 0;
+	border-radius: 3px;
 	background-image: url('../img/mark_read.svg');
 }
 

--- a/css/owncloud6.css
+++ b/css/owncloud6.css
@@ -9,10 +9,11 @@
 }
 
 #app-navigation .rename-feed > input {
-	width: 208px;
 	height: 32px;
 	border-right: 1px solid #ddd;
 	border-radius: 2px;
+	position: relative;
+	top: 5px;
 }
 
 #app-navigation .progress-icon, 


### PR DESCRIPTION
After merging the new layout, buttons were seen like this:

![oc_admin_user_manage1](https://cloud.githubusercontent.com/assets/231068/3216489/52a9814e-efd2-11e3-96ff-5b92fd113812.png)

They will be like this:

![oc_admin_user_manage1](https://cloud.githubusercontent.com/assets/231068/3216571/eb982a30-efd3-11e3-9ed9-64b62a34740b.png)

However, it would be nice to align them to the right. Any help is appreciated :)
