### PR TITLE
Make items more easily clickable

### DIFF
--- a/css/items.css
+++ b/css/items.css
@@ -182,10 +182,11 @@
 	}
 
 	.item_heading h1 a {
+		display: block;
 		font-weight: bold;
 		font-size: 13pt;
 		padding: 0 5px;
-		margin: 0;
+		margin: 0 0 0 70px;
 		line-height: 40px;
 	}
 
@@ -221,6 +222,7 @@
 		display: block;
 		float: right;
 		line-height: 40px;
+		pointer-events: none;
 	}
 
 


### PR DESCRIPTION
Fix for #439/#563

Currently, the title in compact mode is an inline tag, which means that if it starts wrapping to a new line then any white space isn't clickable to expand the article. These changes make it more easily clickable, don't interfere with the "open" and "favourite" buttons, make wrapped titles align more neatly, and prevent the "time ago" text being a dead spot.

This makes "Compact" mode more like stacked sheets of paper - pretty much the whole edge is now "pull it out of the stack because I want to read it" rather than "grab the small and variably sized little bit that has text on it".
