### PR TITLE
DB: Remove unique constraint from index

### DIFF
--- a/appinfo/database.xml
+++ b/appinfo/database.xml
@@ -257,7 +257,6 @@
 			
 			<index>
 				<name>news_items_item_guid</name>
-				<unique>true</unique>
 				<field>
 					<name>guid_hash</name>
 				</field>


### PR DESCRIPTION
Remove unique constraint from `news_items_item_guid` database index.
This unique constraint is violated if multiple users are subscribed to
the same feed.

Discussed with @Raydiation.
