### PR TITLE
Fix <em> tag styling

### DIFF
--- a/css/items.css
+++ b/css/items.css
@@ -19,6 +19,11 @@
  *
  */
 
+.app-news em {
+	opacity: 1;
+	font-style: italic;
+}
+
 #app-content:after {
 	content: '';
 	display: block;


### PR DESCRIPTION
People have apparently been misusing the &lt;em&gt; tag in OwnCloud (https://twitter.com/jancborchardt/status/504004742138572801). Rather than fix the occurrences, OwnCloud made the &lt;em&gt; tag semi-transparent. This means that emphasised text in news feeds is actually de-emphasised. This rule applies only to the news app content and puts the &lt;em&gt; tag back to its normal full-opacity, italic style.
