### PR TITLE
Fixed useless scrollbars

### DIFF
--- a/css/content.css
+++ b/css/content.css
@@ -231,7 +231,7 @@
     }
 
     #app-content .open .utils .title h1 a {
-        overflow: scroll;
+        overflow: auto;
         white-space: normal;
     }
 


### PR DESCRIPTION
Fixed useless scrollbars that appear when you expand a news in compact view (see screenshot)

![scrollbars](https://cloud.githubusercontent.com/assets/1663025/4423363/3c8dd3de-4594-11e4-87b4-abb70cec81c2.jpg)
