### PR TITLE
Update README.rst

### DIFF
--- a/bin/updater/README.rst
+++ b/bin/updater/README.rst
@@ -101,7 +101,7 @@ Then edit the config in **/etc/owncloud/news/updater.ini** with your details and
 
 to test your settings. If everything worked out fine, enable the init script with::
 
-    sudo update-rc.d /etc/init.d/owncloud-news-updater defaults
+    sudo update-rc.d owncloud-news-updater defaults
     sudo /etc/init.d/owncloud-news-updater start
 
 If you make changes to the **updater.ini** file don't forget to reload the service with::


### PR DESCRIPTION
update-rc.d automatically searches in path /etc/init.d. Using the path while calling update-rc.d results in an error.
