### PR TITLE
Added missing ordering attribute

### DIFF
--- a/db/feed.php
+++ b/db/feed.php
@@ -66,6 +66,7 @@ class Feed extends Entity implements IAPI, \JsonSerializable {
     protected $lastModified;
     protected $etag;
     protected $location;
+    protected $ordering;
 
     public function __construct(){
         $this->addType('parentId', 'integer');


### PR DESCRIPTION
This is already implemented in more recent releases. However, the news app 4.3.2 does not work on 7.0.4 due to the lack of ordering attribute on the feed entity.  
Note that 4.3.2 is the last that oficially supports OCv7.

----

This fixes "BadFunctionCallException: ordering is not a valid attribute" error, which is rendering app v4.3.2 useless for oc7.04