### PR TITLE
Improve article enhancer for sueddeutsche.de

### DIFF
--- a/articleenhancer/xpathenhancers.json
+++ b/articleenhancer/xpathenhancers.json
@@ -163,7 +163,7 @@
         "%smashingmagazine.com%": "//article[contains(@class,'post')]/p"
     },
     "sueddeutsche.de": {
-        "%sz.de%": "//article[@id='sitecontent']/section[@class='body']/*[not(contains(@class, 'ad'))]"
+        "%sz.de%": "//article[@id='sitecontent']/section[@class='topenrichment']//img | //article[@id='sitecontent']/section[@class='body']/section[@class='authors']/preceding-sibling::*[not(contains(@class, 'ad'))]"
     },
     "lifehacker.com": {
         "%lifehacker.com%": "//div[contains(@class,'entry-content')]"

--- a/css/custom.css
+++ b/css/custom.css
@@ -15,11 +15,6 @@
     padding: 0 0 0 15px;
 }
 
-#app-content .custom-sueddeutsche-de img + span {
-    display: block;
-}
-
-
-#app-content .custom-sueddeutsche-de a + a {
-    display: block;
+#app-content .custom-sueddeutsche-de .body img {
+    float: none !important;
 }


### PR DESCRIPTION
This improves the article enhancer for sueedeutsche.de to fetch just the
summary from the top of each article instead of the whole article which
bypasses the paywall sueddeutsche.de introduced last week (and that is
not the purpose of the news app, right?). The summary is more detailed
than the one delivered via RSS so the enhancer is still usefull. Plus it
adds the header image of the article.