### PR TITLE
Tweak title spacing to keep size but reduce huge gaps

### DIFF
--- a/css/content.css
+++ b/css/content.css
@@ -322,11 +322,13 @@
         white-space: nowrap;
         overflow: hidden;
         width: 100%;
-        line-height: 40px;
         display: inline-block;
         color: #222;
         font-weight: bold;
         font-size: 16px;
+        line-height: 1.5;
+        padding-top: 8px;
+        min-height: 40px;
     }
 
     #app-content .open .utils .title h1 a {


### PR DESCRIPTION
Particularly in Compact mode, having 40px line height on 16px text results in large spaces in the middle of expanded multi-line titles. This wastes space and looks odd.

The three extra lines of CSS keep the standard positioning the same, keep the click box size the same, but keep headers looking more like:

Some RSS feed item
with two lines

rather than:

Some RSS feed item

with two lines (or is it something different? It is just so far away!)