### PR TITLE
Add missing Admin.js to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -156,6 +156,7 @@ appstore:
 	$(project_directory)"/js/vendor/momentjs/min/moment-with-locales.min.js" \
 	$(project_directory)"/js/vendor/masonry/dist/masonry.pkgd.min.js" \
 	$(project_directory)"/js/build/app.min.js" \
+	$(project_directory)"/js/admin/Admin.js" \
 
 # Command for running JS and PHP tests. Works for package.json files in the js/
 # and root directory. If phpunit is not installed systemwide, a copy is fetched


### PR DESCRIPTION
The Admin.js file is required to access admin settings.
Accessing the admin settings results in an Internal Server Error if the file doesn't exist.

~~~
Apr  1 12:50:30 cloud ownCloud[6186]: {news} Could not find resource file "/apps/news/js/admin/Admin.js"
Apr  1 12:50:33 cloud ownCloud[6186]: {index} Exception: {"Exception":"RuntimeException","Message":"The source file
\"\/var\/www\/owncloud\/apps\/news\/js\/admin\/Admin.js\" does not exist.","Code":0,"Trace":"#0 \/var\/www\/owncloud
\/3rdparty\/kriswallsmith\/assetic\/src\/Assetic\/Asset\/BaseAsset.php(103): Assetic\\Asset\\FileAsset->load()\n#1 \
/var\/www\/owncloud\/3rdparty\/kriswallsmith\/assetic\/src\/Assetic\/Asset\/AssetCollection.php(151): Assetic\\Asset
\\BaseAsset->dump(NULL)\n#2 \/var\/www\/owncloud\/3rdparty\/kriswallsmith\/assetic\/src\/Assetic\/AssetWriter.php(68
): Assetic\\Asset\\AssetCollection->dump()\n#3 \/var\/www\/owncloud\/lib\/private\/templatelayout.php(226): Assetic\
\AssetWriter->writeAsset(Object(Assetic\\Asset\\AssetCollection))\n#4 \/var\/www\/owncloud\/lib\/private\/templatela
yout.php(142): OC\\TemplateLayout->generateAssets()\n#5 \/var\/www\/owncloud\/lib\/private\/template.php(225): OC\\T
emplateLayout->__construct('user', 'settings')\n#6 \/var\/www\/owncloud\/lib\/private\/template\/base.php(122): OC_T
emplate->fetchPage()\n#7 \/var\/www\/owncloud\/settings\/admin.php(252): OC\\Template\\Base->printPage()\n#8 \/var\/
www\/owncloud\/lib\/private\/route\/route.php(154) : runtime-created function(1): require_once('\/var\/www\/ownclo..
.')\n#9 [internal function]: __lambda_func(Array)\n#10 \/var\/www\/owncloud\/lib\/private\/route\/router.php(273): c
all_user_func('\\x00lambda_719', Array)\n#11 \/var\/www\/owncloud\/lib\/base.php(873): OC\\Route\\Router->match('\/s
ettings\/admin')\n#12 \/var\/www\/owncloud\/index.php(39): OC::handleRequest()\n#13 {main}","File":"\/var\/www\/ownc
loud\/3rdparty\/kriswallsmith\/assetic\/src\/Assetic\/Asset\/FileAsset.php","Line":62}
~~~