### PR TITLE
Increase News max-version to 10.0

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -22,7 +22,7 @@
 
     <!-- dependencies -->
     <dependencies>
-        <owncloud min-version="9.0" max-version="9.1"/>
+        <owncloud min-version="9.0" max-version="10.0"/>
         <php min-version="5.6" min-int-size="64"/>
         <database min-version="9.4">pgsql</database>
         <database>sqlite</database>


### PR DESCRIPTION
Owncloud 10.0 was recently released as the stable version and this app stopped working due to the max-version check. News seems to work just fine on owncloud 10.0 once this change is applied.