### PR TITLE
fix(controllers): adapt to new OC core login flow

### DIFF
--- a/controller/apicontroller.php
+++ b/controller/apicontroller.php
@@ -14,13 +14,25 @@
 namespace OCA\News\Controller;
 
 use OCP\IRequest;
+use OCP\IUserSession;
 use OCP\AppFramework\ApiController as BaseApiController;
 
 class ApiController extends BaseApiController {
+    private $userSession;
 
     public function __construct($appName,
-                                IRequest $request){
+                                IRequest $request,
+                                IUserSession $userSession){
         parent::__construct($appName, $request);
+        $this->userSession = $userSession;
+    }
+
+    protected function getUser() {
+        return $this->userSession->getUser();
+    }
+
+    protected function getUserId() {
+        return $this->getUser()->getUID();
     }
 
     /**

--- a/controller/folderapicontroller.php
+++ b/controller/folderapicontroller.php
@@ -14,7 +14,7 @@
 namespace OCA\News\Controller;
 
 use \OCP\IRequest;
-use \OCP\AppFramework\ApiController;
+use \OCP\IUserSession;
 use \OCP\AppFramework\Http;
 
 use \OCA\News\Service\FolderService;
@@ -37,11 +37,10 @@ class FolderApiController extends ApiController {
                                 IRequest $request,
                                 FolderService $folderService,
                                 ItemService $itemService,
-                                $UserId){
-        parent::__construct($AppName, $request);
+                                IUserSession $userSession){
+        parent::__construct($AppName, $request, $userSession);
         $this->folderService = $folderService;
         $this->itemService = $itemService;
-        $this->userId = $UserId;
         $this->serializer = new EntityApiSerializer('folders');
     }
 
@@ -53,7 +52,7 @@ class FolderApiController extends ApiController {
      */
     public function index() {
         return $this->serializer->serialize(
-            $this->folderService->findAll($this->userId)
+            $this->folderService->findAll($this->getUserId())
         );
     }
 
@@ -68,9 +67,9 @@ class FolderApiController extends ApiController {
      */
     public function create($name) {
         try {
-            $this->folderService->purgeDeleted($this->userId, false);
+            $this->folderService->purgeDeleted($this->getUserId(), false);
             return $this->serializer->serialize(
-                $this->folderService->create($name, $this->userId)
+                $this->folderService->create($name, $this->getUserId())
             );
         } catch(ServiceValidationException $ex) {
             return $this->error($ex, Http::STATUS_UNPROCESSABLE_ENTITY);
@@ -90,7 +89,7 @@ class FolderApiController extends ApiController {
      */
     public function delete($folderId) {
         try {
-            $this->folderService->delete($folderId, $this->userId);
+            $this->folderService->delete($folderId, $this->getUserId());
         } catch(ServiceNotFoundException $ex) {
             return $this->error($ex, Http::STATUS_NOT_FOUND);
         }
@@ -109,7 +108,7 @@ class FolderApiController extends ApiController {
      */
     public function update($folderId, $name) {
         try {
-            $this->folderService->rename($folderId, $name, $this->userId);
+            $this->folderService->rename($folderId, $name, $this->getUserId());
 
         } catch(ServiceValidationException $ex) {
             return $this->error($ex, Http::STATUS_UNPROCESSABLE_ENTITY);
@@ -132,7 +131,7 @@ class FolderApiController extends ApiController {
      * @param int $newestItemId
      */
     public function read($folderId, $newestItemId) {
-        $this->itemService->readFolder($folderId, $newestItemId, $this->userId);
+        $this->itemService->readFolder($folderId, $newestItemId, $this->getUserId());
     }
 
 

--- a/controller/itemapicontroller.php
+++ b/controller/itemapicontroller.php
@@ -14,7 +14,7 @@
 namespace OCA\News\Controller;
 
 use \OCP\IRequest;
-use \OCP\AppFramework\ApiController;
+use \OCP\IUserSession;
 use \OCP\AppFramework\Http;
 
 use \OCA\News\Service\ItemService;
@@ -31,10 +31,9 @@ class ItemApiController extends ApiController {
     public function __construct($AppName,
                                 IRequest $request,
                                 ItemService $itemService,
-                                $UserId){
-        parent::__construct($AppName, $request);
+                                IUserSession $userSession){
+        parent::__construct($AppName, $request, $userSession);
         $this->itemService = $itemService;
-        $this->userId = $UserId;
         $this->serializer = new EntityApiSerializer('items');
     }
 
@@ -57,7 +56,7 @@ class ItemApiController extends ApiController {
         return $this->serializer->serialize(
             $this->itemService->findAll(
                 $id, $type, $batchSize, $offset, $getRead, $oldestFirst,
-                $this->userId
+                $this->getUserId()
             )
         );
     }
@@ -76,14 +75,14 @@ class ItemApiController extends ApiController {
     public function updated($type=3, $id=0, $lastModified=0) {
         return $this->serializer->serialize(
             $this->itemService->findAllNew($id, $type, $lastModified,
-                                           true, $this->userId)
+                                           true, $this->getUserId())
         );
     }
 
 
     private function setRead($isRead, $itemId) {
         try {
-            $this->itemService->read($itemId, $isRead, $this->userId);
+            $this->itemService->read($itemId, $isRead, $this->getUserId());
         } catch(ServiceNotFoundException $ex){
             return $this->error($ex, Http::STATUS_NOT_FOUND);
         }
@@ -121,7 +120,7 @@ class ItemApiController extends ApiController {
     private function setStarred($isStarred, $feedId, $guidHash) {
         try {
             $this->itemService->star(
-                $feedId, $guidHash, $isStarred, $this->userId
+                $feedId, $guidHash, $isStarred, $this->getUserId()
             );
         } catch(ServiceNotFoundException $ex){
             return $this->error($ex, Http::STATUS_NOT_FOUND);
@@ -167,14 +166,14 @@ class ItemApiController extends ApiController {
      * @param int $newestItemId
      */
     public function readAll($newestItemId) {
-        $this->itemService->readAll($newestItemId, $this->userId);
+        $this->itemService->readAll($newestItemId, $this->getUserId());
     }
 
 
     private function setMultipleRead($isRead, $items) {
         foreach($items as $id) {
             try {
-                $this->itemService->read($id, $isRead, $this->userId);
+                $this->itemService->read($id, $isRead, $this->getUserId());
             } catch(ServiceNotFoundException $ex) {
                 continue;
             }
@@ -210,7 +209,7 @@ class ItemApiController extends ApiController {
         foreach($items as $item) {
             try {
                 $this->itemService->star($item['feedId'], $item['guidHash'],
-                                               $isStarred, $this->userId);
+                                               $isStarred, $this->getUserId());
             } catch(ServiceNotFoundException $ex) {
                 continue;
             }


### PR DESCRIPTION
... introduced by owncloud/core#30421, released in OC 10.0.8

This PR leverages the base APIController in order to store the UserSession instead of the userId, because the authentication is now performed later in the flow.